### PR TITLE
cancelar viaje con penalizacion

### DIFF
--- a/controllers/usuarioController.php
+++ b/controllers/usuarioController.php
@@ -286,7 +286,7 @@ class usuarioController extends Controller {
         }
         require_once ROOT . 'models' . DS . 'vehiculoModel.php';
         $vehiculoModel = new vehiculoModel();
-        $usuario = Session::get("usuario");
+        $usuario = $this->_usuario->getUsuario(Session::get("id_usuario"));
         $vehiculos = $vehiculoModel->getVehiculosByUserId($usuario['id']);
         $travels = $this->_viajes->getViajesAbiertos();
         $usuario['cantViajesChofer'] = $this->_viajes->getCantViajesChofer($usuario['id']);
@@ -341,7 +341,7 @@ class usuarioController extends Controller {
             $this->_usuario->beginTransaction();
             $postulacion = $this->_viajes->getPostulacion($idPostu);
             if ($postulacion["id_estado"] == 2) {
-                $this->_notificacion->crearNotificacionSimple("El usuario " . $usuario["nombre"] . " " . $usuario["apellido"] . " cancelo su postulacion al viaje nº " . $idViaje, $idChofer);
+                $this->_notificacion->crearNotificacionSimple("Haz sido penalizado con -1 punto de reputacion por cancelar una postulacion aceptada al viaje nº " . $idViaje, $postulacion["id_pasajero"]);
                 $this->_usuario->calificacionAutomatica($postulacion["id_pasajero"], -1);
                 $this->_usuario->actualizarReputacion($postulacion["id_pasajero"], -1);
             }

--- a/models/facturaModel.php
+++ b/models/facturaModel.php
@@ -59,6 +59,31 @@ class facturaModel extends Model {
     }
     
     
+    /**
+     * cambia el estado de una factua a ACTIVA(2) 
+     * @param type $form
+     */
+    public function activarFactura($idFactura) {
+        $sql = "update facturas set id_estado = 2 where id = :id_factura";
+        $params = array(
+            ":id_factura" => $idFactura
+        );
+        $this->_db->execute($sql, $params);
+    }
+    
+    /**
+     * cambia el estado de una factua a ACTIVA(2) 
+     * @param type $form
+     */
+    public function activarFacturaDeViaje($idViaje) {
+        $sql = "update facturas set id_estado = 2 where id_viaje = :id_viaje";
+        $params = array(
+            ":id_viaje" => $idViaje
+        );
+        $this->_db->execute($sql, $params);
+    }
+    
+    
     
 
 }

--- a/models/viajeModel.php
+++ b/models/viajeModel.php
@@ -74,10 +74,23 @@ class viajeModel extends Model {
      * @param type $idviaje
      * @return type
      */
-    public function getPostulacionesAceptadas($idviaje) {
+    public function getPostulacionesAceptadasCant($idviaje) {
         $sql = "select * from postulacion where id_viaje = :id_viaje and id_estado = 2";
         $this->_db->execute($sql, array(":id_viaje" => $idviaje));
         return $this->_db->rowCount();
+    }
+
+    /**
+     * 
+     * Retorna la cantidad de postuilaciones aceptadas para un viaje.
+     * 
+     * @param type $idviaje
+     * @return type
+     */
+    public function getPostulacionesAceptadas($idviaje) {
+        $sql = "select * from postulacion where id_viaje = :id_viaje and id_estado = 2";
+        $this->_db->execute($sql, array(":id_viaje" => $idviaje));
+        return $this->_db->fetchAll();
     }
 
     /**

--- a/views/viaje/detalle.html.twig
+++ b/views/viaje/detalle.html.twig
@@ -468,6 +468,18 @@
                         });
                     });
             {% endif %}
+        {% else %}
+                $("#cancelarViaje").click(function () {
+                    var msj;
+                    msj = "Recuerda las reglas de UnAventon: \n\
+            Si el viaje no tiene tiene postulaciones aceptadas no hay ningun problema, pero\n\
+            si aceptaste postulaciones tendras -1 punto reputacion por cancelar un viaje \n\
+            con postulaciones aceptadas y -1 punto por cada postulacion aceptada.";
+                    var ok = confirm(msj);
+                    if (!ok) {
+                        return false;
+                    }
+                });
         {% endif %}
             });
     </script>


### PR DESCRIPTION
Al cancelar un viaje se verifica si tiene pasajeros aceptados y, de tenerlos, se resta 1 punto de reputación por cada uno y 1 punto extra por la cancelación en si.
También se genera la activación de la factura asociada al viaje (generando una deuda que prohíbe publicar viajes hasta que se pague.)
Genera notificacion a todos los usuarios postulados (aceptados o no)
genera notificacion de penalizacino al chofer
genera notificacion de factura lista al chofer